### PR TITLE
Feature/service manager 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.5",
         "slim/slim": "^3.0",
-        "zendframework/zend-servicemanager": "^2.5"
+        "zendframework/zend-servicemanager": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "12ac2da4ea8fbb331530909f7d77f286",
-    "content-hash": "5d730c44bd8de89afcfc49f7bef0e5e5",
+    "hash": "b525f7cfb2b87fad4acd06ec8f4f15f9",
+    "content-hash": "8fd8c4e3e432f1a8d807a44167b8d7c7",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -174,16 +174,16 @@
         },
         {
             "name": "slim/slim",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slimphp/Slim.git",
-                "reference": "3b06f0f2d84dabbe81b6cea46ace46a3e883253e"
+                "reference": "03b44a4b41896ba42c78bbd5fa172cd79e650496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slimphp/Slim/zipball/3b06f0f2d84dabbe81b6cea46ace46a3e883253e",
-                "reference": "3b06f0f2d84dabbe81b6cea46ace46a3e883253e",
+                "url": "https://api.github.com/repos/slimphp/Slim/zipball/03b44a4b41896ba42c78bbd5fa172cd79e650496",
+                "reference": "03b44a4b41896ba42c78bbd5fa172cd79e650496",
                 "shasum": ""
             },
             "require": {
@@ -194,7 +194,8 @@
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0"
+                "phpunit/phpunit": "^4.0",
+                "squizlabs/php_codesniffer": "^2.5"
             },
             "type": "library",
             "autoload": {
@@ -236,41 +237,40 @@
                 "micro",
                 "router"
             ],
-            "time": "2015-12-07 14:11:09"
+            "time": "2016-01-08 15:37:50"
         },
         {
             "name": "zendframework/zend-servicemanager",
-            "version": "2.6.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "1dc33f23bd0a7f4d8ba743b915fae523d356027a"
+                "reference": "460f96f3cc5406d35aeb9782a4847a5fb061cd83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/1dc33f23bd0a7f4d8ba743b915fae523d356027a",
-                "reference": "1dc33f23bd0a7f4d8ba743b915fae523d356027a",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/460f96f3cc5406d35aeb9782a4847a5fb061cd83",
+                "reference": "460f96f3cc5406d35aeb9782a4847a5fb061cd83",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "~1.0",
-                "php": ">=5.5"
+                "php": "^5.5 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-di": "~2.5",
-                "zendframework/zend-mvc": "~2.5"
+                "athletic/athletic": "dev-master",
+                "ocramius/proxy-manager": "~1.0",
+                "phpunit/phpunit": "~4.6",
+                "squizlabs/php_codesniffer": "^2.0@dev"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager 0.5.* to handle lazy initialization of services",
-                "zendframework/zend-di": "Zend\\Di component"
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
                 }
             },
             "autoload": {
@@ -284,10 +284,11 @@
             ],
             "homepage": "https://github.com/zendframework/zend-servicemanager",
             "keywords": [
+                "service-manager",
                 "servicemanager",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-07-23 21:49:08"
+            "time": "2016-01-11 18:50:12"
         }
     ],
     "packages-dev": [],

--- a/src/Container.php
+++ b/src/Container.php
@@ -196,7 +196,17 @@ final class Container extends ServiceManager implements ArrayAccess
      */
     public function offsetUnset($id)
     {
-        $this->setService($id, null);
+        // Unset the alias, service or factory
+        if (isset($this->aliases[$id])) {
+            // Call set alias so that it is internally resolved
+            $this->setAlias($id, null);
+        }
+        if (isset($this->services[$id])) {
+            unset($this->services[$id]);
+        }
+        if (isset($this->factories[$id])) {
+            unset($this->factories[$id]);
+        }
     }
 
     /********************************************************************************

--- a/src/Container.php
+++ b/src/Container.php
@@ -9,7 +9,6 @@
 namespace RKA\ZsmSlimContainer;
 
 use ArrayAccess;
-use Interop\Container\ContainerInterface;
 use RuntimeException;
 use Slim\CallableResolver;
 use Slim\Handlers\Error;
@@ -40,7 +39,7 @@ use Zend\ServiceManager\ServiceManager;
  *  - notAllowedHandler: a callable with the signature: function($request, $response, $allowedHttpMethods)
  *  - callableResolver: an instance of \Slim\Interfaces\CallableResolverInterface
  */
-final class Container extends ServiceManager implements ContainerInterface, ArrayAccess
+final class Container extends ServiceManager implements ArrayAccess
 {
     /**
      * Default settings

--- a/src/Container.php
+++ b/src/Container.php
@@ -8,29 +8,20 @@
  */
 namespace RKA\ZsmSlimContainer;
 
-use Zend\ServiceManager\ServiceManager;
-use Zend\ServiceManager\Config as ServiceManagerConfig;
-use Interop\Container\ContainerInterface;
 use ArrayAccess;
-use Interop\Container\Exception\ContainerException;
+use Interop\Container\ContainerInterface;
 use RuntimeException;
-
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Slim\Exception\NotFoundException;
+use Slim\CallableResolver;
 use Slim\Handlers\Error;
-use Slim\Handlers\NotFound;
 use Slim\Handlers\NotAllowed;
+use Slim\Handlers\NotFound;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Http\Environment;
 use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
-use Slim\CallableResolver;
 use Slim\Router;
-use Slim\Interfaces\CallableResolverInterface;
-use Slim\Interfaces\Http\EnvironmentInterface;
-use Slim\Interfaces\RouterInterface;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * Extend Zend\ServiceManager for use with Slim
@@ -141,8 +132,7 @@ final class Container extends ServiceManager implements ContainerInterface, Arra
             $settings['invokables']['notAllowedHandler'] = NotAllowed::class;
         }
 
-        $config = new ServiceManagerConfig($settings);
-        parent::__construct($config);
+        parent::__construct($settings);
     }
 
     /**
@@ -162,16 +152,16 @@ final class Container extends ServiceManager implements ContainerInterface, Arra
     {
         if (is_object($value)) {
             if ($value instanceof \Closure) {
-                return $this->setFactory($id, $value);
+                $this->setFactory($id, $value);
             }
-            return $this->setService($id, $value);
+            $this->setService($id, $value);
         }
 
         if (is_string($value) && class_exists($value)) {
-            return $this->setInvokableClass($id, $value);
+            $this->setInvokableClass($id, $value);
         }
 
-        return $this->setService($id, $value);
+        $this->setService($id, $value);
     }
 
     /**
@@ -207,7 +197,7 @@ final class Container extends ServiceManager implements ContainerInterface, Arra
      */
     public function offsetUnset($id)
     {
-        return $this->unregisterService($id);
+        $this->setService($id, null);
     }
 
     /********************************************************************************


### PR DESCRIPTION
This updates the component to depend on zend-servicemanager v3.

This is what I've changed:
- Updated the zendframework/zend-servicemanager component version
- The Zend\ServiceManager v3 doesn't need a `Zend\ServiceManager\Config` instance anymore, so I've removed it
- The `Zend\ServiceManager\ServiceLocatorInterface` extends from `Interop\Container\ContainerInterface` in this version, so I've removed the implementation from the `RKA\ZsmSlimContainer\Container` class
- I have removed some return statements, since v3 does not implement a fluid interface anymore and returns nothing.
- I have updated the `offsetUnset` method that was calling a protected method that has been removed.

It has been small changes.
I haven't added any test, because I've seen there are no other tests, and everything can be fairly tested by using the example app.
However, If you want me to add some tests, I could do it.
